### PR TITLE
Register nav button on SkinTemplateNavigation::Universal (MW 1.43)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -35,7 +35,7 @@
 		"MarkMajorChangesLangLinksExemptNamespaces": []
 	},
 	"Hooks": {
-		"SkinTemplateNavigation": [
+		"SkinTemplateNavigation::Universal": [
 			"MarkMajorChangesHooks::onSkinTemplateNavigation"
 		],
 		"ListDefinedTags": [


### PR DESCRIPTION
## Problem

After the MediaWiki 1.43 upgrade, the **"שינוי מהותי" / "Major change"** action stopped appearing on the article toolbar for staff users on staging — with no error and no deprecation warning.

Root cause: `extension.json` registers the button under the legacy **`SkinTemplateNavigation`** hook, which MediaWiki core **no longer fires** in 1.43. `SkinTemplate::runOnSkinTemplateNavigationHooks()` invokes only `SkinTemplateNavigation::Universal`; the plain and `::SpecialPage` variants were removed (not even present in `DeprecatedHooks`), so the handler is silently never called and `addMarkButton()` never runs.

Verified on staging that the extension is loaded, the `staff` group holds both `markmajorchange` and `changetags`, and `Dockerstaff`'s effective rights include both — so the permission gate would pass; only the dead hook prevented the button from rendering.

## Fix

Point the handler at the surviving `SkinTemplateNavigation::Universal` hook. `MarkMajorChangesHooks::onSkinTemplateNavigation( SkinTemplate &$sktemplate, array &$links )` is already signature-compatible with the Universal hook, so no handler change is needed.

## Testing

- `extension.json` validated as JSON.
- Manual verification to follow once the parent-repo submodule pointer is bumped and a staging image is rebuilt.