### PR TITLE
Add Playwright e2e tests for the toolbar action and log page

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/package-lock.json
+/playwright-report
+/test-results

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,46 @@
+# MarkMajorChanges e2e tests
+
+Playwright end-to-end tests for the MarkMajorChanges extension. They lock in the
+MW 1.43 modernization: the "mark major change" toolbar action is registered on
+the surviving `SkinTemplateNavigation::Universal` hook (the legacy hook silently
+stopped firing on 1.43, which had removed the button), and `Special:MajorChangesLog`
+still renders.
+
+The action link is gated on the `changetags` + `markmajorchange` rights, so the
+suite asserts it is **visible to a staff user** and **absent for anonymous
+visitors**. Assertions are by href (`?action=markmajorchange`), independent of the
+wiki content language.
+
+## Setup
+
+```sh
+cd tests
+npm install
+npx playwright install chromium
+```
+
+## Run
+
+The anonymous check runs with no credentials. The staff-only checks **skip**
+(they never silently pass) unless credentials are supplied.
+
+```sh
+# against local dev (main site, he)
+MW_USERNAME=Dockerstaff MW_PASSWORD=<dev-password> \
+  npx playwright test
+
+# against another target
+MW_BASE_URL=https://staging-test.wikirights.org.il MW_SCRIPT_PATH=/w/he \
+MW_USERNAME=Dockerstaff MW_PASSWORD=<vault-password> \
+  npx playwright test
+```
+
+## Environment variables
+
+| Variable          | Default                 | Purpose                                     |
+|-------------------|-------------------------|---------------------------------------------|
+| `MW_BASE_URL`     | `http://localhost:8082` | Wiki base URL                               |
+| `MW_SCRIPT_PATH`  | `/he`                   | Language/path prefix to the wiki            |
+| `MW_ARTICLE_PATH` | the wiki root           | Content page to check the action on         |
+| `MW_USERNAME`     | — (skips if unset)      | A `staff`-group user (e.g. Dockerstaff)     |
+| `MW_PASSWORD`     | — (skips if unset)      | That user's password                        |

--- a/tests/e2e/markmajorchanges.spec.ts
+++ b/tests/e2e/markmajorchanges.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { MarkMajorChangesPage } from '../pages/MarkMajorChangesPage';
+
+/**
+ * MarkMajorChanges — toolbar action + log special page.
+ *
+ * Regression cover for the MW 1.43 modernization: the "mark major change"
+ * action is registered on the surviving `SkinTemplateNavigation::Universal`
+ * hook via an instance-based HookHandler, so it must render again for a staff
+ * user (the legacy hook silently stopped firing on 1.43, removing the button).
+ *
+ * The action link is gated on the `changetags` + `markmajorchange` rights, so:
+ *   - a staff user (MW_USERNAME/MW_PASSWORD) sees it,
+ *   - an anonymous visitor does not.
+ *
+ * Special:MajorChangesLog must also render (its pager/DI were reworked).
+ */
+
+const USERNAME = process.env.MW_USERNAME ?? '';
+const PASSWORD = process.env.MW_PASSWORD ?? '';
+
+test.describe('MarkMajorChanges', () => {
+  test('the action is hidden from anonymous visitors', async ({ page }) => {
+    const mmc = new MarkMajorChangesPage(page);
+    await mmc.gotoArticle();
+    // Permission gate: anon lacks markmajorchange.
+    await expect(mmc.markMajorChangeAction()).toHaveCount(0);
+  });
+
+  test.describe('as a staff user', () => {
+    test.skip(
+      !USERNAME || !PASSWORD,
+      'Set MW_USERNAME / MW_PASSWORD (a staff-group user, e.g. Dockerstaff) to run the authenticated specs.'
+    );
+
+    test('the "mark major change" toolbar action renders on an article', async ({ page }) => {
+      const mmc = new MarkMajorChangesPage(page);
+      await mmc.login(USERNAME, PASSWORD);
+      await mmc.gotoArticle();
+      // The Universal-hook handler re-adds the action for staff.
+      await expect(mmc.markMajorChangeAction().first()).toBeVisible();
+    });
+
+    test('Special:MajorChangesLog renders without a fatal', async ({ page }) => {
+      const mmc = new MarkMajorChangesPage(page);
+      await mmc.login(USERNAME, PASSWORD);
+      await mmc.gotoLog();
+      await expect(page.locator('body')).not.toContainText('Internal error');
+      await expect(page.locator('body')).not.toContainText('Fatal error');
+      // The log special page renders an OOUI filter form.
+      await expect(page.locator('form')).not.toHaveCount(0);
+    });
+  });
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "markmajorchanges-extension-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright e2e suite for the MarkMajorChanges extension (toolbar action + log special page).",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:debug": "playwright test --debug",
+    "typecheck": "tsc --noEmit",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/tests/pages/MarkMajorChangesPage.ts
+++ b/tests/pages/MarkMajorChangesPage.ts
@@ -1,0 +1,45 @@
+import { Page, Locator } from '@playwright/test';
+
+/**
+ * Page object for the MarkMajorChanges toolbar action and its log special page.
+ *
+ * The action is a page-navigation link (`?action=markmajorchange`), so it is
+ * located by its href rather than its localized label — language-independent.
+ */
+export class MarkMajorChangesPage {
+  readonly page: Page;
+  readonly scriptPath: string;
+  readonly articlePath: string;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.scriptPath = process.env.MW_SCRIPT_PATH || '/he';
+    // Default to the wiki root (the main page) — always present. Override with
+    // MW_ARTICLE_PATH to target a specific content page.
+    this.articlePath = process.env.MW_ARTICLE_PATH || `${this.scriptPath}/`;
+  }
+
+  /** Form-based login via Special:UserLogin. */
+  async login(username: string, password: string): Promise<void> {
+    await this.page.goto(`${this.scriptPath}/Special:UserLogin`);
+    await this.page.getByRole('textbox').first().fill(username);
+    await this.page.locator('input[type="password"]').fill(password);
+    await this.page.locator('button[type="submit"], #wpLoginAttempt').first().click();
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async gotoArticle(): Promise<void> {
+    await this.page.goto(this.articlePath);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async gotoLog(): Promise<void> {
+    await this.page.goto(`${this.scriptPath}/Special:MajorChangesLog`);
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  /** The "mark major change" action link, if present in the page chrome. */
+  markMajorChangeAction(): Locator {
+    return this.page.locator('a[href*="action=markmajorchange"]');
+  }
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for the MarkMajorChanges extension e2e tests.
+ *
+ * Run:
+ *   npx playwright test
+ *
+ * Environment variables:
+ *   MW_BASE_URL     - MediaWiki base URL (default: http://localhost:8082)
+ *   MW_SCRIPT_PATH  - path prefix to the wiki (default: /he)
+ *   MW_ARTICLE_PATH - a content page to check the action on (default: the wiki root)
+ *   MW_USERNAME     - a user in the `staff` group (holds markmajorchange + changetags)
+ *   MW_PASSWORD     - that user's password
+ *
+ * The "mark major change" toolbar action only shows for a staff user, so the
+ * authenticated specs skip cleanly when MW_USERNAME/MW_PASSWORD are unset.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: ['**/*.spec.ts'],
+  timeout: 30000,
+  expect: { timeout: 7000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+
+  reporter: [
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+    ['list'],
+  ],
+
+  use: {
+    baseURL: process.env.MW_BASE_URL || 'http://localhost:8082',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'markmajorchanges-desktop',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+  ],
+});

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["e2e/**/*.ts", "pages/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
Adds a Playwright e2e suite under `tests/` (following the `skins/Cassandra/tests/` convention) that locks in the MW 1.43 modernization (PR #4).

## Coverage
- **Action hidden from anon** — the `?action=markmajorchange` link is absent without the `markmajorchange` right.
- **Action visible to staff** — after login as a `staff` user, the toolbar action renders on a content page (regression guard for the `SkinTemplateNavigation::Universal` hook migration — the legacy hook silently stopped firing on 1.43).
- **Special:MajorChangesLog renders** — HTTP-200, no "Internal error"/"Fatal error", filter form present (guards the special-page + pager DI rework).

## Design
- The action is located by **href** (`action=markmajorchange`), not label — language-independent.
- Staff-only specs **skip cleanly** unless `MW_USERNAME`/`MW_PASSWORD` (a staff user, e.g. Dockerstaff) are set; the anon check always runs.

## Verified
`MW_USERNAME=Dockerstaff MW_PASSWORD=… npx playwright test` against local dev (MW 1.43): **3/3 passed**. `tsc --noEmit` clean; `node_modules`/reports/lockfile gitignored. See `tests/README.md`.