### PR TITLE
Restore custom tag/update log rendering under MW 1.43 (#7)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -49,6 +49,7 @@
 			"value": []
 		}
 	},
+	"callback": "MediaWiki\\Extension\\MarkMajorChanges\\Hooks::onRegistration",
 	"HookHandlers": {
 		"main": {
 			"class": "MediaWiki\\Extension\\MarkMajorChanges\\Hooks",

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -22,6 +22,22 @@ class Hooks implements
 	}
 
 	/**
+	 * Extension registration callback.
+	 *
+	 * Override the core formatter for `tag/update` log entries with our own.
+	 * This must happen at load time (during Setup), not at request time: in
+	 * MW 1.43 LogFormatterFactory reads $wgLogActionsHandlers once into a
+	 * ServiceOptions snapshot when the service is first built, so a runtime
+	 * mutation no longer takes effect. It also cannot be done via
+	 * extension.json "LogActionsHandlers", because that merge gives an existing
+	 * core key precedence over the extension's value. See #7.
+	 */
+	public static function onRegistration(): void {
+		global $wgLogActionsHandlers;
+		$wgLogActionsHandlers['tag/update'] = MajorChangesTagLogFormatter::class;
+	}
+
+	/**
 	 * Add our change tags to the list of defined tags.
 	 *
 	 * @param string[] &$tags

--- a/includes/MajorChangeAction.php
+++ b/includes/MajorChangeAction.php
@@ -603,10 +603,17 @@ class MajorChangeAction extends FormAction {
 			$logEntry->setTarget( SpecialPage::getTitleFor( 'Tags' ) );
 		}
 
+		// Write the full tag/update parameter set (including the empty
+		// "removed" pair) so the entries stay well-formed for core
+		// TagLogFormatter, which reads 9:number:tagsRemovedCount. Omitting
+		// them triggers an "undefined array key" warning wherever core
+		// formats the entry (e.g. Special:Log). See #7.
 		$logParams = [
 			'4::revid' => $rev_id,
 			'6:list:tagsAdded' => $tags,
 			'7:number:tagsAddedCount' => count( $tags ),
+			'8:list:tagsRemoved' => [],
+			'9:number:tagsRemovedCount' => 0,
 		];
 		$logEntry->setParameters( $logParams );
 		$logEntry->setRelations( [ 'Tag' => $tags ] );

--- a/includes/MajorChangesLogPager.php
+++ b/includes/MajorChangesLogPager.php
@@ -37,9 +37,10 @@ class MajorChangesLogPager extends LogPager {
 	) {
 		$this->connectionProvider = $connectionProvider;
 
-		// Override TagLogFormatter. We don't want to override it system-wide, just here
-		global $wgLogActionsHandlers;
-		$wgLogActionsHandlers['tag/update'] = MajorChangesTagLogFormatter::class;
+		// The formatter for tag/update is registered at load time in
+		// Hooks::onRegistration. Runtime $wgLogActionsHandlers mutation (the
+		// previous approach here) no longer takes effect in MW 1.43 —
+		// LogFormatterFactory snapshots the config. See #7.
 
 		$this->status    = $opts->getValue( 'status' );
 		$this->startDate = $opts->getValue( 'start' );

--- a/includes/MajorChangesTagLogFormatter.php
+++ b/includes/MajorChangesTagLogFormatter.php
@@ -22,10 +22,21 @@ use MediaWiki\MediaWikiServices;
 use TagLogFormatter;
 
 /**
- * This class formats tag log entries.
- * It is an extension of the default TagLogFormatter,
- * in order to add diff links. The extension overrides
- * $wgLogActionsHandlers
+ * This class formats tag log entries created by MarkMajorChanges, adding a
+ * custom message and a diff link.
+ *
+ * It is registered as the system-wide handler for `tag/update` at load time
+ * (Hooks::onRegistration), so it must behave exactly like the default
+ * TagLogFormatter for every tag/update entry that is NOT ours. It discriminates
+ * on the entry's own tags: an entry is "ours" iff every tag it touches is one
+ * of the extension's tags (see MarkMajorChanges::getMainTagName /
+ * getSecondaryTagName). This keeps unrelated tag log entries — including the
+ * "mark done" entries, which carry a different tag — rendered by core.
+ *
+ * Registration happens at load time rather than at request time because in
+ * MW 1.43 LogFormatterFactory snapshots $wgLogActionsHandlers into a
+ * ServiceOptions the first time it is built; a runtime mutation (the previous
+ * approach) no longer takes effect. See #7.
  *
  * Parameters (one-based indexes):
  * 4::revid
@@ -39,17 +50,50 @@ use TagLogFormatter;
  * injection), so the LinkRenderer is fetched from the service container.
  */
 class MajorChangesTagLogFormatter extends TagLogFormatter {
+
 	/**
-	 * prevent user tool links after the username.
+	 * Whether this tag/update entry was created by MarkMajorChanges, i.e. every
+	 * tag it touches belongs to the extension. Non-owned entries (ordinary tag
+	 * changes, "mark done" entries) fall through to core rendering.
+	 *
+	 * @return bool
+	 */
+	private function isOwnEntry(): bool {
+		$params = $this->entry->getParameters();
+		$tags = array_merge(
+			$params['6:list:tagsAdded'] ?? [],
+			$params['8:list:tagsRemoved'] ?? []
+		);
+		if ( $tags === [] ) {
+			return false;
+		}
+
+		$ownTags = [
+			MarkMajorChanges::getMainTagName(),
+			MarkMajorChanges::getSecondaryTagName(),
+		];
+
+		return array_diff( $tags, $ownTags ) === [];
+	}
+
+	/**
+	 * Prevent user tool links after the username, but only for our own entries.
 	 * @param bool $value
 	 */
 	public function setShowUserToolLinks( $value ) {
-		$this->linkFlood = false;
+		if ( $this->isOwnEntry() ) {
+			$this->linkFlood = false;
+			return;
+		}
+		parent::setShowUserToolLinks( $value );
 	}
 
 	/** @inheritDoc */
 	protected function getMessageKey() {
-		return 'logentry-majorchanges';
+		if ( $this->isOwnEntry() ) {
+			return 'logentry-majorchanges';
+		}
+		return parent::getMessageKey();
 	}
 
 	/**
@@ -57,18 +101,23 @@ class MajorChangesTagLogFormatter extends TagLogFormatter {
 	 * @inheritDoc
 	 */
 	public function getActionLinks() {
+		if ( !$this->isOwnEntry() ) {
+			return parent::getActionLinks();
+		}
+
 		$links = parent::getActionLinks();
 
-		$params = $this->getMessageParameters();
-		if ( isset( $params[3] ) ) {
-			$oldid = $params[3];
+		// Use the raw revid for the diff target; getMessageParameters()
+		// replaces the same slot with a formatted link, not a usable id.
+		$revId = $this->entry->getParameters()['4::revid'] ?? null;
+		if ( $revId ) {
 			$linkRenderer = MediaWikiServices::getInstance()->getLinkRenderer();
 			$diffLink = $linkRenderer->makeKnownLink(
 				$this->entry->getTarget(),
 				$this->msg( 'diff' )->escaped(),
 				[],
 				[
-					'oldid' => $oldid,
+					'oldid' => $revId,
 					'diff' => 'prev',
 				]
 			);

--- a/tests/phpunit/integration/MajorChangesTagLogFormatterTest.php
+++ b/tests/phpunit/integration/MajorChangesTagLogFormatterTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace MediaWiki\Extension\MarkMajorChanges\Tests\Integration;
+
+use ManualLogEntry;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Extension\MarkMajorChanges\MajorChangesTagLogFormatter;
+use MediaWiki\Linker\LinkRenderer;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use Wikimedia\TestingAccessWrapper;
+
+/**
+ * @covers \MediaWiki\Extension\MarkMajorChanges\MajorChangesTagLogFormatter
+ * @group MarkMajorChanges
+ */
+class MajorChangesTagLogFormatterTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * Build a tag/update log entry and format it through the real
+	 * LogFormatterFactory, exactly as MediaWiki does when rendering a log line.
+	 * Going through the factory is deliberate: it proves the formatter is
+	 * actually selected for tag/update (Hooks::onRegistration), which is the
+	 * behaviour that broke under MW 1.43. See #7.
+	 *
+	 * @param array $params Raw log parameters (e.g. 6:list:tagsAdded)
+	 * @return \LogFormatter
+	 */
+	private function formatterFor( array $params ) {
+		// Stub the LinkRenderer so getActionLinks() can build the diff link
+		// without a database (tests run DB-disabled). getActionLinks() pulls the
+		// renderer from the service container, so replacing the service is enough.
+		$linkRenderer = $this->createMock( LinkRenderer::class );
+		$linkRenderer->method( 'makeKnownLink' )->willReturnCallback(
+			static fn ( $target, $text = null, $extra = [], $query = [] ) =>
+				'<a href="?' . http_build_query( $query ) . '">'
+				. ( is_string( $text ) ? $text : 'link' ) . '</a>'
+		);
+		$this->setService( 'LinkRenderer', $linkRenderer );
+
+		$entry = new ManualLogEntry( 'tag', 'update' );
+		$entry->setPerformer( $this->getServiceContainer()->getUserFactory()->newAnonymous() );
+		$entry->setTarget( Title::newFromText( 'Main Page' ) );
+		$entry->setParameters( $params );
+
+		$formatter = $this->getServiceContainer()
+			->getLogFormatterFactory()
+			->newFromEntry( $entry );
+
+		$context = new RequestContext();
+		$context->setLanguage( 'en' );
+		$formatter->setContext( $context );
+
+		return $formatter;
+	}
+
+	/**
+	 * The extension's own entries: add-only, tagged with the extension's tags.
+	 * Note the missing 8/9 "removed" params — this is the real historical shape
+	 * that tripped core TagLogFormatter's "Undefined array key" warning once the
+	 * runtime formatter override stopped working.
+	 */
+	private static function ownParams(): array {
+		return [
+			'4::revid' => 601491,
+			'6:list:tagsAdded' => [ 'majorchange' ],
+			'7:number:tagsAddedCount' => 1,
+		];
+	}
+
+	public function testTagUpdateIsHandledByOurFormatter() {
+		$formatter = $this->formatterFor( self::ownParams() );
+		$this->assertInstanceOf(
+			MajorChangesTagLogFormatter::class,
+			$formatter,
+			'onRegistration must register our formatter for tag/update'
+		);
+	}
+
+	public function testOwnEntryUsesCustomMessageKey() {
+		$formatter = $this->formatterFor( self::ownParams() );
+		// getMessageKey() reads only parameters, and our path never touches
+		// 9:number:tagsRemovedCount — so this also asserts the regression
+		// warning is gone (the test would fail on any PHP warning).
+		$this->assertSame(
+			'logentry-majorchanges',
+			TestingAccessWrapper::newFromObject( $formatter )->getMessageKey()
+		);
+	}
+
+	public function testOwnEntryAddsDiffLink() {
+		$links = $this->formatterFor( self::ownParams() )->getActionLinks();
+		$this->assertStringContainsString( 'diff=prev', $links );
+		$this->assertStringContainsString( 'oldid=601491', $links );
+	}
+
+	/**
+	 * A run-of-the-mill tag change (unrelated tag) must fall through to core
+	 * rendering, not be hijacked with the major-changes message.
+	 */
+	public function testForeignEntryFallsBackToCore() {
+		$formatter = $this->formatterFor( [
+			'4::revid' => 601491,
+			'6:list:tagsAdded' => [ 'mw-reverted' ],
+			'7:number:tagsAddedCount' => 1,
+			'8:list:tagsRemoved' => [],
+			'9:number:tagsRemovedCount' => 0,
+		] );
+
+		$this->assertStringStartsWith(
+			'logentry-tag-update',
+			TestingAccessWrapper::newFromObject( $formatter )->getMessageKey()
+		);
+		$this->assertSame( '', $formatter->getActionLinks() );
+	}
+
+	/**
+	 * The "mark done" flow tags entries with a *different* tag
+	 * ("שינוי מהותי טופל"), which is not one of the extension's own tags, so
+	 * those entries must also render through core.
+	 */
+	public function testHandledTagEntryFallsBackToCore() {
+		$formatter = $this->formatterFor( [
+			'4::revid' => null,
+			'5::logid' => 999,
+			'6:list:tagsAdded' => [ 'שינוי מהותי טופל' ],
+			'7:number:tagsAddedCount' => 1,
+			'8:list:tagsRemoved' => [],
+			'9:number:tagsRemovedCount' => 0,
+		] );
+
+		$this->assertStringStartsWith(
+			'logentry-tag-update',
+			TestingAccessWrapper::newFromObject( $formatter )->getMessageKey()
+		);
+	}
+}


### PR DESCRIPTION
## What & why

Fixes #7. Opening **Special:MajorChangesLog** on MW 1.43 emitted a PHP warning
per row and rendered the generic tag-log message instead of the extension's
`logentry-majorchanges` message + diff link:

```
Undefined array key "9:number:tagsRemovedCount"
 in includes/logging/TagLogFormatter.php on line 82
```

**Root cause:** `MajorChangesLogPager` swapped the `tag/update` formatter by
mutating `$wgLogActionsHandlers` at request time. In MW 1.43 formatter
construction moved into the `LogFormatterFactory` service, which reads that
config **once** into a `ServiceOptions` snapshot when first built — so the
runtime mutation is ignored and core `TagLogFormatter` renders our entries,
reading a "removed tags" param our `logTagAdded()` never wrote.

## Changes

- **`Hooks::onRegistration`** (new `callback`) registers the formatter for
  `tag/update` at **load time**, before the service snapshot is taken.
  (`extension.json` `LogActionsHandlers` can't be used here — its merge gives an
  existing *core* key precedence over the extension's value, so it wouldn't
  override `tag/update`.)
- **`MajorChangesTagLogFormatter`** now **discriminates**: it renders the custom
  message + diff link only when every tag the entry touches is one of the
  extension's own tags (`majorchange` / `arabic`); otherwise it delegates to
  core. This makes a single system-wide registration safe on the special page,
  the API, and `Special:Log?type=tag` alike, and leaves unrelated `tag/update`
  entries (including "mark done", which carries a different tag) untouched.
  Also fixes the diff link to use the raw revid.
- **`MajorChangeAction::logTagAdded`** writes the empty
  `8:list:tagsRemoved` / `9:number:tagsRemovedCount` pair so new entries stay
  well-formed for core wherever they are shown.
- Removed the dead runtime `$wgLogActionsHandlers` mutation.

## Verification (dev, `--wiki=he`, against real historical entries)

Exercised the real `LogFormatterFactory` path on an actual malformed entry
(`log_id 438283`) and synthetic entries, with a PHP error handler capturing all
diagnostics:

- Before: `formatter class: TagLogFormatter` + `Undefined array key
  "9:number:tagsRemovedCount"`.
- After: `formatter class: MajorChangesTagLogFormatter`, **no** target warning,
  diff link present, custom message rendered
  (`…סימן את גרסה 601491 של עמוד ראשי בתגיות majorchange`).
- Discriminator: own→`logentry-majorchanges`; `mw-reverted`→core message;
  handled-tag "mark done"→core message. Confirmed core `ChangeTags` writes the
  full param set, so real foreign entries never warn.
- `composer test` (parallel-lint + phpcs + minus-x) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
