### PR TITLE
Only offer "mark major change" on existing content pages

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -67,6 +67,11 @@ class Hooks implements
 	 * Add the "mark major change" action to the page toolbar for users who may
 	 * apply the change tag.
 	 *
+	 * The action tags an existing revision (and reads its langlinks, categories,
+	 * etc.), so it only makes sense on a real content page. Skip it on titles
+	 * that cannot hold content — Special:/Media: pages, where canExist() is
+	 * false — and on pages that do not yet exist, which have no revision to tag.
+	 *
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinTemplateNavigation::Universal
 	 *
 	 * @param \SkinTemplate $sktemplate The skin template on which the UI is built.
@@ -75,6 +80,10 @@ class Hooks implements
 	public function onSkinTemplateNavigation__Universal( $sktemplate, &$links ): void {
 		$title = $sktemplate->getRelevantTitle();
 		$user = $sktemplate->getUser();
+
+		if ( !$title->canExist() || !$title->exists() ) {
+			return;
+		}
 
 		if ( $this->permissionManager->userHasAllRights( $user, 'changetags', 'markmajorchange' ) ) {
 			$links['actions']['markmajorchange'] = [

--- a/tests/phpunit/integration/HooksNavigationTest.php
+++ b/tests/phpunit/integration/HooksNavigationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace MediaWiki\Extension\MarkMajorChanges\Tests\Integration;
+
+use MediaWiki\Extension\MarkMajorChanges\Hooks;
+use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Title\Title;
+use MediaWikiIntegrationTestCase;
+use SkinTemplate;
+
+/**
+ * @covers \MediaWiki\Extension\MarkMajorChanges\Hooks::onSkinTemplateNavigation__Universal
+ * @group MarkMajorChanges
+ * @group Database
+ */
+class HooksNavigationTest extends MediaWikiIntegrationTestCase {
+
+	/**
+	 * Run the navigation hook for a given relevant title, with a permission
+	 * manager that always grants the required rights, so the only thing left to
+	 * gate the action link is the title check itself.
+	 *
+	 * @param Title $title The skin's relevant title.
+	 * @return array The navigation links array after the hook runs.
+	 */
+	private function runHookFor( Title $title ): array {
+		$permissionManager = $this->createMock( PermissionManager::class );
+		$permissionManager->method( 'userHasAllRights' )->willReturn( true );
+
+		$skin = $this->createMock( SkinTemplate::class );
+		$skin->method( 'getRelevantTitle' )->willReturn( $title );
+		$skin->method( 'getUser' )->willReturn(
+			$this->getServiceContainer()->getUserFactory()->newAnonymous()
+		);
+		// msg() is only reached once the link is actually built.
+		$skin->method( 'msg' )->willReturnCallback(
+			static fn ( $key ) => wfMessage( $key )
+		);
+
+		$links = [ 'actions' => [] ];
+		( new Hooks( $permissionManager ) )
+			->onSkinTemplateNavigation__Universal( $skin, $links );
+
+		return $links;
+	}
+
+	public function testActionShownOnExistingContentPage() {
+		$title = $this->getExistingTestPage( 'MarkMajorChanges test page' )->getTitle();
+		$links = $this->runHookFor( $title );
+		$this->assertArrayHasKey(
+			'markmajorchange', $links['actions'],
+			'The action must appear on an existing content page.'
+		);
+	}
+
+	public function testActionHiddenOnSpecialPage() {
+		// Special pages cannot hold content: canExist() is false.
+		$links = $this->runHookFor( Title::newFromText( 'Recentchanges', NS_SPECIAL ) );
+		$this->assertArrayNotHasKey(
+			'markmajorchange', $links['actions'],
+			'The action must not appear on a Special: page.'
+		);
+	}
+
+	public function testActionHiddenOnNonExistentPage() {
+		$title = $this->getNonexistingTestPage( 'MarkMajorChanges missing page' )->getTitle();
+		$links = $this->runHookFor( $title );
+		$this->assertArrayNotHasKey(
+			'markmajorchange', $links['actions'],
+			'The action must not appear on a page with no revision to tag.'
+		);
+	}
+}


### PR DESCRIPTION
## Problem

The **mark major change** toolbar action was shown on *every* page a user
with `markmajorchange` + `changetags` viewed — including `Special:` and
`Media:` pages and not-yet-created pages. The `SkinTemplateNavigation::Universal`
handler only checked the user's rights, never the title.

That's wrong beyond cosmetics: `MajorChangeAction` operates on a real
revision (`getLatestRevID()`, `getArticleID()`, langlinks, categories). On
a special page those are meaningless, and `getArticleID()`/`getId()` on a
non-existable title can assert under MW 1.43.

## Fix

Gate the navigation link on the relevant title being **content-capable and
existing**:

```php
if ( !$title->canExist() || !$title->exists() ) {
    return;
}
```

- `canExist()` is false for `Special:`/`Media:` (NS < 0) → excludes special pages.
- `exists()` ensures there is actually a revision to tag → excludes redlinks.

Using `canExist()` rather than hardcoding content namespaces keeps the
extension's intentional support for non-content namespaces via
`MarkMajorChangesLangLinksExemptNamespaces`.

## Tests

New `HooksNavigationTest` covers all three paths: action shown on an
existing content page, hidden on `Special:`, hidden on a non-existent page.
Full extension suite green (10 tests).